### PR TITLE
Process default export last.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,13 +121,13 @@ module.exports = function(content) {
     // };
     // ```
     return format(config, [
-      styles.default,
       mapKeys(
         omit(styles, 'default'),
         function (value, key) {
           return '.' + key;
         }
       ),
+      styles.default,
     ]);
   }
 


### PR DESCRIPTION
Babel adds the default export after any named exports. This change ensures the generated css markup preserves the same order.
